### PR TITLE
test: isolate test runner environment and silence treesitter warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /lua.bat
 /lua_modules
 /.luarocks
+/test_lsp.log

--- a/runtests.lua
+++ b/runtests.lua
@@ -7,6 +7,12 @@ local function setup_env()
 	vim.opt.shortmess:append("c")
 
 	vim.lsp.log.set_level(vim.log.levels.DEBUG)
+
+	-- Silence treesitter parser missing warnings during headless tests
+	pcall(function()
+		---@diagnostic disable-next-line: duplicate-set-field
+		vim.treesitter.start = function() end
+	end)
 end
 
 local function print_msg(msg)

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cleanup() {
+	if [[ -n "$TEST_TMP_DIR" && -d "$TEST_TMP_DIR" && "$TEST_TMP_DIR" == /tmp/mssql-test-env-* ]]; then
+		rm -rf "$TEST_TMP_DIR"
+	fi
+}
+trap cleanup EXIT INT TERM
+
+export NVIM_APPNAME="mssql-nvim-test-suite"
+
+# persistent caching directory - persists across runs and reboots
+# allows use of SKIP_DOWNLOAD env var to reuse existing SQL Tools Service binary
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share/mssql-test-data}"
+
+# temporary directories for isolation and cleanup of config/state/backup files
+# files generated during test execution
+TEST_TMP_DIR=$(mktemp -d /tmp/mssql-test-env-XXXXXX)
+readonly TEST_TMP_DIR
+export TEST_TMP_DIR
+export XDG_CONFIG_HOME="$TEST_TMP_DIR/config"
+export XDG_STATE_HOME="$TEST_TMP_DIR/state"
+
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME"
+
+export DbServer="${DbServer:-localhost}"
+export DbUser="${DbUser:-sa}"
+export DbPassword="${DbPassword:-Test_Password_123}"
+export DbDatabase="${DbDatabase:-tempdb}"
+export SKIP_DOWNLOAD="${SKIP_DOWNLOAD:-1}"
+
+command -v nvim >/dev/null || {
+	echo "nvim required" >&2
+	exit 1
+}
+
+[[ -f "runtests.lua" ]] || {
+	echo "runtests.lua not found" >&2
+	exit 1
+}
+#
+echo "Test directory: $TEST_TMP_DIR"
+echo "Data directory: $XDG_DATA_HOME"
+echo "Skip download: $SKIP_DOWNLOAD"
+
+# first run will download the binaries to ~/.local/share/mssql-test-data/mssql-nvim-test-suite/mssql.nvim
+nvim -u runtests.lua --headless
+
+# for now move tests lsp.log into repo root before cleanup is run
+if [[ -f "$XDG_STATE_HOME/${NVIM_APPNAME}/logs/lsp.log" ]]; then
+	mv "$XDG_STATE_HOME/${NVIM_APPNAME}/logs/lsp.log" ./test_lsp.log
+fi


### PR DESCRIPTION
Since mitigating the move to returning vim.NIL from LSP in nvim 0.12 we are no longer using older versions of nvim (0.11) for testing suite. This commit is to shore up testing suite in anticipation of eventually migrating to mini.test or some other established framework.

- Add a wrapper script `runtests.sh` to containerize the Neovim test execution using isolated XDG paths and a custom `NVIM_APPNAME`.
- Persist `XDG_DATA_HOME` under a dedicated caching folder to enable bandwidth-saving tools reuse with `SKIP_DOWNLOAD`.
- Extract `lsp.log` to the project root as `test_lsp.log` for debugging convenience and ignore it in `.gitignore`.
- Override `vim.treesitter.start` to a no-op in `runtests.lua` to silence spurious warnings about missing Treesitter markdown parsers.

Closes #8 